### PR TITLE
Update link to integration guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Criteo Adapters for Mopub Mediation (Android)
-This repository contains Criteo’s Adapter for Mopub Mediation. It must be used in conjunction with the Criteo Publisher SDK. For requirements, intructions, and other info, see [Integrating Criteo with Mopub Mediation](https://publisherdocs.criteotilt.com/sdk-android/3.1/mopub-mediation/).
+This repository contains Criteo’s Adapter for Mopub Mediation. It must be used in conjunction with the Criteo Publisher SDK. For requirements, intructions, and other info, see [Integrating Criteo with Mopub Mediation](https://publisherdocs.criteotilt.com/app/android/mediation/mopub/).
 
 # Download
 Add the following maven repository into your top-level *build.gradle* file:


### PR DESCRIPTION
Update link to integration guide to the new documentation. Although the old link still works and redirects to the new link, the redirect may be decommissioned in near future.