### PR TITLE
Fix development of Bintray artifacts

### DIFF
--- a/mediation/build.gradle
+++ b/mediation/build.gradle
@@ -217,7 +217,7 @@ publishing {
 
 bintray {
     user = System.getenv("BINTRAY_USER")
-    key = System.getenv("BINTRAY_PASSWORD")
+    key = System.getenv("BINTRAY_KEY")
     publish = true
     publications = ["release"]
 


### PR DESCRIPTION
The "password" terminology was used before because the old CI used it.
There is no preferences on the new Github Action, so now, we match the
Bintray's terminology: "key"

JIRA: EE-1164