### PR TITLE
Run instrumentation tests in Github Action and fix tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  build:
+  java-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,12 +29,45 @@ jobs:
           path: "**/TEST-*.xml"
           testSrcPath: "mediation/src/test/java"
 
+  android-tests:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Android SDK
+        uses: malinskiy/action-android/install-sdk@release/0.0.7
+
+      - name: Run Android tests
+        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
+        with:
+          api: 29
+          tag: google_apis
+          cmd: ./gradlew connectedCheck
+
+      - name: Upload logcat output
+        uses: actions/upload-artifact@master
+        if: failure()
+        with:
+          name: logcat
+          path: artifacts/logcat.log
+
+      # It is not possible to use the junit-report-annotations-action as for java test.
+      # MacOS will be supported on next version: https://github.com/ashley-taylor/junit-report-annotations-action/issues/8
+      - name: Upload JUnit report
+        uses: actions/upload-artifact@master
+        if: failure()
+        with:
+          name: junit-report
+          path: "**/build/reports/androidTests"
+
   deploy-development-artifacts:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
 
     needs:
-      - build
+      - java-tests
+      - android-tests
 
     steps:
       - name: Checkout

--- a/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
+++ b/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
@@ -146,10 +146,7 @@ class CriteoNativeAdapterTest {
     adChoiceView.assertClickRedirectTo(expectedAssets.privacyOptOutClickUrl, false)
 
     // Image
-    // FIXME: the image loading is done by async and is not synchronized in the waitForIdleState.
-    //  The assertions on click above gains times for the images to be loaded. Hence, those
-    //  assertions may fail is the loading of the image is too long. In such case, adding a
-    //  Thread.sleep should be sufficient to "fix" the asserts.
+    waitForPicasso()
     assertThat(adView.findDrawableWithTag(PRODUCT_IMAGE_TAG)).isNotNull.isNotEqualTo(placeholder)
     assertThat(adView.findDrawableWithTag(ADVERTISER_LOGO_TAG)).isEqualTo(placeholder)
     assertThat(adChoiceView.drawable).isNotNull
@@ -254,6 +251,13 @@ class CriteoNativeAdapterTest {
 
     val quantifier = if (notifyMoPubListener) times(1) else never()
     verify(nativeEventListener, quantifier).onClick(anyOrNull())
+  }
+
+  private fun waitForPicasso() {
+    // Picasso is not synchronized through the waitForIdleState.
+    // Hence it is not possible to reliably wait for downloaded images.
+    // This sleep should at least do the job.
+    Thread.sleep(1000)
   }
 
 }


### PR DESCRIPTION
In parallel of Java tests, instrumentation tests should be run on a
single emulator. If emulator crashes, logcat should be available as a
temporary build artifact. If test fails, test report should be available
as a temporary build artifact.

As this is totally new, some tests are expected to fail and are fixed.

JIRA: EE-1165