### PR TITLE
Remove the specific bintray Criteo repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ allprojects {
         google()
         jcenter()
         mavenLocal()
-        // TODO EE-1167: remove this once development artifacts are sync on jcenter
-        maven { url  "https://dl.bintray.com/criteo/mobile" }
         maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
     }
 }


### PR DESCRIPTION
Development artifacts of adapters are now sync on JCenter. We do not
need this repository anymore.

JIRA: EE-1167