### PR TITLE
Deactivate flaky assertions

### DIFF
--- a/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
+++ b/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
@@ -32,7 +32,6 @@ import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.AD
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.CALL_TO_ACTION_TAG
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.DESCRIPTION_TAG
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.PRICE_TAG
-import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.PRODUCT_IMAGE_TAG
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.TITLE_TAG
 import com.criteo.publisher.CriteoUtil.TEST_CP_ID
 import com.criteo.publisher.CriteoUtil.givenInitializedCriteo
@@ -146,10 +145,14 @@ class CriteoNativeAdapterTest {
     adChoiceView.assertClickRedirectTo(expectedAssets.privacyOptOutClickUrl, false)
 
     // Image
-    waitForPicasso()
-    assertThat(adView.findDrawableWithTag(PRODUCT_IMAGE_TAG)).isNotNull.isNotEqualTo(placeholder)
+    // FIXME EE-1180: Test does not pass on Github Actions
+    //  Picasso is not synchronized through the waitForIdleState.
+    //  Hence it is not possible to reliably wait for downloaded images.
+    //  Even a sleep of 1 second does not work on slow env such as CI.
+    // assertThat(adView.findDrawableWithTag(PRODUCT_IMAGE_TAG)).isNotNull.isNotEqualTo(placeholder)
     assertThat(adView.findDrawableWithTag(ADVERTISER_LOGO_TAG)).isEqualTo(placeholder)
-    assertThat(adChoiceView.drawable).isNotNull
+    // FIXME EE-1180: Same than above
+    // assertThat(adChoiceView.drawable).isNotNull
   }
 
   @Test
@@ -254,9 +257,7 @@ class CriteoNativeAdapterTest {
   }
 
   private fun waitForPicasso() {
-    // Picasso is not synchronized through the waitForIdleState.
-    // Hence it is not possible to reliably wait for downloaded images.
-    // This sleep should at least do the job.
+
     Thread.sleep(1000)
   }
 


### PR DESCRIPTION
Those assertions are flaky because Picasso download is not synchronized
via the waitForIdleState. Even a sleep of 1 second does not seems to
help on a slow environment such as a CI. They should be reactivated by
EE-1180.