### PR TITLE
Reactivate assert that were ignored because of flakyness

### DIFF
--- a/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
+++ b/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
@@ -31,6 +31,7 @@ import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.AD
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.CALL_TO_ACTION_TAG
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.DESCRIPTION_TAG
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.PRICE_TAG
+import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.PRODUCT_IMAGE_TAG
 import com.criteo.mediation.mopub.advancednative.TestNativeRenderer.Companion.TITLE_TAG
 import com.criteo.publisher.CriteoUtil.TEST_CP_ID
 import com.criteo.publisher.CriteoUtil.givenInitializedCriteo
@@ -144,14 +145,9 @@ class CriteoNativeAdapterTest {
     adChoiceView.assertClickRedirectTo(expectedAssets.privacyOptOutClickUrl, false)
 
     // Image
-    // FIXME EE-1180: Test does not pass on Github Actions
-    //  Picasso is not synchronized through the waitForIdleState.
-    //  Hence it is not possible to reliably wait for downloaded images.
-    //  Even a sleep of 1 second does not work on slow env such as CI.
-    // assertThat(adView.findDrawableWithTag(PRODUCT_IMAGE_TAG)).isNotNull.isNotEqualTo(placeholder)
+    assertThat(adView.findDrawableWithTag(PRODUCT_IMAGE_TAG)).isNotNull.isNotEqualTo(placeholder)
     assertThat(adView.findDrawableWithTag(ADVERTISER_LOGO_TAG)).isEqualTo(placeholder)
-    // FIXME EE-1180: Same than above
-    // assertThat(adChoiceView.drawable).isNotNull
+    assertThat(adChoiceView.drawable).isNotNull
   }
 
   @Test


### PR DESCRIPTION
Those asserts were deactivated because Picasso was not be sync via
waitForIdleState. This is fixed in:
https://github.com/criteo/android-publisher-sdk/pull/26