### PR TITLE
Use main a new default branch name for the upload-artifact GA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           access-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload JUnit report
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@main
         if: failure()
         with:
           name: junit-report
@@ -51,7 +51,7 @@ jobs:
           cmd: ./gradlew connectedCheck
 
       - name: Upload logcat output
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@main
         if: failure()
         with:
           name: logcat
@@ -64,7 +64,7 @@ jobs:
           access-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload JUnit report
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@main
         if: failure()
         with:
           name: junit-report


### PR DESCRIPTION
This GA is now using "main" as default branch. Using the master one
yield this warning:

The "master" branch is no longer the default branch name for
actions/upload-artifact
Please pin to a specific version or use "main".