### PR TITLE
Add E2E tests on Profile ID

### DIFF
--- a/mediation/src/androidTest/java/com/criteo/mediation/mopub/ProfileIdFunctionalTest.kt
+++ b/mediation/src/androidTest/java/com/criteo/mediation/mopub/ProfileIdFunctionalTest.kt
@@ -1,0 +1,86 @@
+package com.criteo.mediation.mopub
+
+import com.criteo.mediation.mopub.advancednative.CriteoNativeAdapter
+import com.criteo.mediation.mopub.advancednative.NativeAdapterHelper
+import com.criteo.publisher.CriteoUtil.givenInitializedCriteo
+import com.criteo.publisher.TestAdUnits.*
+import com.criteo.publisher.csm.MetricHelper
+import com.criteo.publisher.csm.MetricSendingQueueConsumer
+import com.criteo.publisher.integration.Integration.MOPUB_MEDIATION
+import com.criteo.publisher.mock.MockedDependenciesRule
+import com.criteo.publisher.mock.SpyBean
+import com.criteo.publisher.network.PubSdkApi
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class ProfileIdFunctionalTest {
+
+  @Rule
+  @JvmField
+  val mockedDependenciesRule = MockedDependenciesRule()
+
+  @SpyBean
+  private lateinit var metricSendingQueueConsumer: MetricSendingQueueConsumer
+
+  @SpyBean
+  private lateinit var api: PubSdkApi
+
+  @Test
+  fun loadBanner_GivenSdkUsedOrNot_UseAdapterProfileIdInAllRequests() {
+    val adapterHelper = BannerAdapterHelper(CriteoBannerAdapter())
+    adapterHelper.loadBanner(BANNER_320_480, mock())
+    mockedDependenciesRule.waitForIdleState()
+
+    assertAdapterProfileIdIsUsedInAllRequests()
+  }
+
+  @Test
+  fun loadInterstitial_GivenSdkUsedOrNot_UseAdapterProfileIdInAllRequests() {
+    val adapterHelper = InterstitialAdapterHelper(CriteoInterstitialAdapter())
+    adapterHelper.loadInterstitial(INTERSTITIAL, mock())
+    mockedDependenciesRule.waitForIdleState()
+
+    assertAdapterProfileIdIsUsedInAllRequests()
+  }
+
+  @Test
+  fun loadNative_GivenSdkUsedOrNot_UseAdapterProfileIdInAllRequests() {
+    val adapterHelper = NativeAdapterHelper(CriteoNativeAdapter())
+    adapterHelper.loadNative(NATIVE, mock())
+    mockedDependenciesRule.waitForIdleState()
+
+    assertAdapterProfileIdIsUsedInAllRequests()
+  }
+
+  private fun assertAdapterProfileIdIsUsedInAllRequests() {
+    verify(api).loadConfig(check {
+      assertThat(it.profileId).isEqualTo(MOPUB_MEDIATION.profileId)
+    })
+
+    verify(api).loadCdb(check {
+      assertThat(it.profileId).isEqualTo(MOPUB_MEDIATION.profileId)
+    }, any())
+
+    triggerMetricRequest()
+
+    verify(api).postCsm(check {
+      with(MetricHelper) {
+        assertThat(it.internalProfileId).isEqualTo(MOPUB_MEDIATION.profileId)
+      }
+    })
+  }
+
+  private fun triggerMetricRequest() {
+    // CSM are put in queue during SDK init but they are not sent, so we need to trigger it.
+    givenInitializedCriteo()
+    mockedDependenciesRule.waitForIdleState()
+    metricSendingQueueConsumer.sendMetricBatch()
+    mockedDependenciesRule.waitForIdleState()
+  }
+
+}

--- a/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
+++ b/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/CriteoNativeAdapterTest.kt
@@ -251,9 +251,4 @@ class CriteoNativeAdapterTest {
     verify(nativeEventListener, quantifier).onClick(anyOrNull())
   }
 
-  private fun waitForPicasso() {
-
-    Thread.sleep(1000)
-  }
-
 }

--- a/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/NativeAdapterHelper.kt
+++ b/mediation/src/androidTest/java/com/criteo/mediation/mopub/advancednative/NativeAdapterHelper.kt
@@ -1,0 +1,23 @@
+package com.criteo.mediation.mopub.advancednative
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.criteo.mediation.mopub.MoPubHelper.serverExtras
+import com.criteo.publisher.CriteoUtil.TEST_CP_ID
+import com.criteo.publisher.concurrent.ThreadingUtil.runOnMainThreadAndWait
+import com.criteo.publisher.model.NativeAdUnit
+import com.mopub.nativeads.CustomEventNative
+
+class NativeAdapterHelper(private val adapter: CriteoNativeAdapter) {
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  fun loadNative(adUnit: NativeAdUnit, listener: CustomEventNative.CustomEventNativeListener) {
+    val serverExtras = serverExtras(TEST_CP_ID, adUnit.adUnitId)
+
+    runOnMainThreadAndWait {
+      adapter.loadNativeAd(context, listener, mapOf(), serverExtras)
+    }
+  }
+
+}


### PR DESCRIPTION
# Tested scenario

## Adapter profile id is used when loading any type of creative

This is true for all types of creative:
- Banner
- Interstitial
- Advanced Native

- Given SDK used or not
- When mediation adapter is asked for an ad
- And waiting for idle state
- Then CDB request contains the adapter profile ID
- Then remote config request contains the adapter profile ID
- Then CSM request contains the adapter profile ID

JIRA: EE-1205