### PR TITLE
Setup Gordon Gradle plugin to retry failing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           api: 29
           tag: google_apis
-          cmd: ./gradlew connectedCheck
+          cmd: ./gradlew gordon
 
       - name: Upload logcat output
         uses: actions/upload-artifact@main
@@ -68,7 +68,7 @@ jobs:
         if: failure()
         with:
           name: junit-report
-          path: "**/build/reports/androidTests"
+          path: "**/build/reports/"
 
   deploy-development-artifacts:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -19,13 +19,15 @@
 buildscript {
 
     repositories {
+        gradlePluginPortal()
         google()
         jcenter()
-        maven { url "https://s3.amazonaws.com/moat-sdk-builds" }
+        maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.70"
+        classpath "com.banno.gordon:gordon-plugin:1.4.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/mediation/build.gradle
+++ b/mediation/build.gradle
@@ -20,7 +20,10 @@ plugins {
     id "kotlin-android"
     id("com.vanniktech.android.javadoc") version "0.3.0"
     id("com.jfrog.bintray") version "1.8.5"
+    id("com.banno.gordon")
 }
+
+gordon.retryQuota = 3
 
 android {
     compileSdkVersion 29


### PR DESCRIPTION
Setup Gordon Gradle plugin to retry failing tests

This will retry failing tests up to 3 times. This plugin wrap the
connected Android tests and its main features are:
- Retrying failing tests
- Generating JUnit XML reports (with syserr for recovered flaky tests)
- Generating HTML reports with failing/recovering/passing tests
- Printing ongoing tests in stdout without --info on Gradle logger

Why do we need it ?
![image](https://user-images.githubusercontent.com/3816099/88792286-479f9c00-d19b-11ea-8ab3-b20ee7ee5486.png)
