### PR TITLE
Declare the SDK as an API dependency for Advanced Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note that all version `X.Y.Z.T` of this adapter have been tested against the mat
 `X.Y.Z` of the Publisher SDK.
 
 ## Next
+* Fix visibility over the Criteo SDK at compile time for Advanced Native
 
 ## 3.8.0.0
 * Refactor non-native adapter classes to use the new consolidated API from MoPub.

--- a/mediation/build.gradle
+++ b/mediation/build.gradle
@@ -80,11 +80,11 @@ dependencies {
     def mopubVersion = "5.13.1"
 
     if (isSnapshot) {
-        releaseImplementation("com.criteo.publisher:criteo-publisher-sdk-development:$sdk_version+")
+        releaseApi("com.criteo.publisher:criteo-publisher-sdk-development:$sdk_version+")
     } else {
-        releaseImplementation("com.criteo.publisher:criteo-publisher-sdk:$sdk_version")
+        releaseApi("com.criteo.publisher:criteo-publisher-sdk:$sdk_version")
     }
-    debugImplementation("com.criteo.publisher:criteo-publisher-sdk-debug:$sdk_version+")
+    debugApi("com.criteo.publisher:criteo-publisher-sdk-debug:$sdk_version+")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
 


### PR DESCRIPTION
For Advanced Native, publishers need to register their own Criteo
renderer. Hence they need the SDK as an API (compile in POM) dependency