### PR TITLE
🩹 Don't crash when MoPub banner is loaded from worker thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note that all version `X.Y.Z.T` of this adapter have been tested against the mat
 `X.Y.Z` of the Publisher SDK.
 
 ## Next version
+* Support loading of banner from worker thread
 
 ## Version 4.5.0.0
 * No changes on the adapter.

--- a/mediation/src/androidTest/java/com/mopub/mobileads/MoPubInterstitialExt.kt
+++ b/mediation/src/androidTest/java/com/mopub/mobileads/MoPubInterstitialExt.kt
@@ -1,6 +1,6 @@
 package com.mopub.mobileads
 
-import com.criteo.publisher.concurrent.ThreadingUtil.runOnMainThreadAndWait
+import android.os.Looper
 import com.mopub.mobileads.MoPubInterstitial.InterstitialState.LOADING
 import com.mopub.network.AdResponse
 
@@ -11,8 +11,12 @@ import com.mopub.network.AdResponse
  * ad and invoke the success callback.
  */
 fun MoPubInterstitial.loadAd(adResponse: AdResponse) {
-  currentInterstitialState = LOADING
-  runOnMainThreadAndWait {
-    getAdViewController()?.onAdLoadSuccess(adResponse)
+  // MoPub needs a looper to be prepared because it is creating an handler used for timeout. We
+  // don't need to actually loop it as we don't mind about the timeout.
+  if (Looper.myLooper() == null) {
+    Looper.prepare()
   }
+
+  currentInterstitialState = LOADING
+  getAdViewController()?.onAdLoadSuccess(adResponse)
 }

--- a/mediation/src/androidTest/java/com/mopub/mobileads/MoPubViewExt.kt
+++ b/mediation/src/androidTest/java/com/mopub/mobileads/MoPubViewExt.kt
@@ -1,6 +1,6 @@
 package com.mopub.mobileads
 
-import com.criteo.publisher.concurrent.ThreadingUtil.runOnMainThreadAndWait
+import android.os.Looper
 import com.mopub.network.AdResponse
 
 /**
@@ -10,7 +10,11 @@ import com.mopub.network.AdResponse
  * ad and invoke the success callback.
  */
 fun MoPubView.loadAd(adResponse: AdResponse) {
-  runOnMainThreadAndWait {
-    getAdViewController()?.onAdLoadSuccess(adResponse)
+  // MoPub needs a looper to be prepared because it is creating an handler used for timeout. We
+  // don't need to actually loop it as we don't mind about the timeout.
+  if (Looper.myLooper() == null) {
+    Looper.prepare()
   }
+
+  getAdViewController()?.onAdLoadSuccess(adResponse)
 }

--- a/mediation/src/main/java/com/criteo/mediation/mopub/CriteoBannerAdapter.kt
+++ b/mediation/src/main/java/com/criteo/mediation/mopub/CriteoBannerAdapter.kt
@@ -17,6 +17,8 @@ package com.criteo.mediation.mopub
 
 import android.app.Activity
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.criteo.publisher.CriteoBannerView
 import com.criteo.publisher.model.AdSize
 import com.criteo.publisher.model.BannerAdUnit
@@ -69,11 +71,15 @@ class CriteoBannerAdapter @VisibleForTesting internal constructor(
     try {
       val bannerAdUnit = BannerAdUnit(adUnitId, adSize)
       val listener = CriteoBannerEventListener(mLoadListener) { mInteractionListener }
-      bannerView = CriteoBannerView(context, bannerAdUnit).apply {
-        setCriteoBannerAdListener(listener)
-        loadAd()
+
+      ThreadingUtil.instance.runOnUiThread {
+        bannerView = CriteoBannerView(context, bannerAdUnit).apply {
+          setCriteoBannerAdListener(listener)
+          loadAd()
+        }
+
+        MoPubLog.log(LOAD_ATTEMPTED, TAG, "BannerView is loading")
       }
-      MoPubLog.log(LOAD_ATTEMPTED, TAG, "BannerView is loading")
     } catch (e: Exception) {
       MoPubLog.log(LOAD_FAILED, TAG, "Initialization failed")
       mLoadListener.onAdLoadFailed(INTERNAL_ERROR)

--- a/mediation/src/main/java/com/criteo/mediation/mopub/ThreadingUtil.kt
+++ b/mediation/src/main/java/com/criteo/mediation/mopub/ThreadingUtil.kt
@@ -1,0 +1,28 @@
+package com.criteo.mediation.mopub
+
+import android.os.Handler
+import android.os.Looper
+
+internal open class ThreadingUtil {
+
+  private val uiHandler: Handler by lazy { Handler(Looper.getMainLooper()) }
+
+  open fun runOnUiThread(command: () -> Unit) {
+    if (Thread.currentThread() === uiHandler.looper.thread) {
+      command.invoke()
+    } else {
+      uiHandler.post(command)
+    }
+  }
+
+  /**
+   * Singleton instance because the adapters are instantiated by MoPub and should have a 0-arg
+   * constructor, so using a singleton allows the tests to mock this.
+   */
+  companion object {
+    private val lazyInstance: ThreadingUtil by lazy { ThreadingUtil() }
+
+    @JvmStatic
+    var instance = lazyInstance
+  }
+}

--- a/mediation/src/test/java/com/criteo/mediation/mopub/CriteoBannerAdapterTest.java
+++ b/mediation/src/test/java/com/criteo/mediation/mopub/CriteoBannerAdapterTest.java
@@ -31,6 +31,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -103,6 +106,13 @@ public class CriteoBannerAdapterTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+
+    ThreadingUtil.setInstance(new ThreadingUtil() {
+      @Override
+      public void runOnUiThread(@NotNull Function0<Unit> command) {
+        command.invoke();
+      }
+    });
   }
 
   @Test


### PR DESCRIPTION
We assumed that MoPub load method should only be called from the UI
thread. Even if MoPub is recommending this, it might happens that some
apps are not following this and are actually calling the load on a
worker thread.

When loading the banner, a WebView is instantiated. This operation is
only permitted on the UI thread. Hence it crashes. This fix make the
adapter jump on the UI-thread if it is not already on it, avoiding the
crash then.

See https://github.com/mopub/mopub-android-sdk/issues/511 to see
discussion with MoPub.

Fixed issue: https://github.com/criteo/android-publisher-sdk/issues/246