### PR TITLE
📇 Updated developer email address to use one decoupled from Criteo internal org

### DIFF
--- a/mediation/build.gradle
+++ b/mediation/build.gradle
@@ -212,7 +212,7 @@ publishing {
                     // We rely on Git to recognize contributors
                     developer {
                         name = "R&D Direct"
-                        email = "rnd-direct@criteo.com"
+                        email = "pubsdk-owner@criteo.com"
                         organization = "Criteo"
                         organizationUrl = "https://www.criteo.com/"
                     }


### PR DESCRIPTION
[rnd-direct@criteo.com](mailto:rnd-direct@criteo.com) will disapear. Instead of using the new team ML, we should use a static component oriented ML and use ML ownership in Office365 to associate it to the proper org team.